### PR TITLE
File input

### DIFF
--- a/input-file/file-input.go
+++ b/input-file/file-input.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ShowMax/go-fqdn"
+
 	"github.com/veino/processors"
 	"github.com/veino/veino"
 
@@ -29,50 +31,116 @@ type processor struct {
 	q                   chan bool
 	wg                  sync.WaitGroup
 	sinceDBInfosMutex   *sync.Mutex
+	host                string
 }
 
 type options struct {
-	Add_field              map[string]interface{}
-	Close_older            int // 3600
-	Codec                  string
-	Delimiter              string // \n
-	Discover_interval      int    // 15
-	Exclude                []string
-	Ignore_older           int // 86400
-	Max_open_files         string
-	Path                   []string `validate:"required"`
-	Sincedb_path           string
-	Sincedb_write_interval int    // 15
-	Start_position         string // end
-	Stat_interval          int    // 1
-	Tags                   []string
-	Type                   string
+	// Add a field to an event. Default value is {}
+	AddField map[string]interface{} `mapstructure:"add_field"`
+
+	// Closes any files that were last read the specified timespan in seconds ago.
+	// Default value is 3600 (i.e. 1 hour)
+	// This has different implications depending on if a file is being tailed or read.
+	// If tailing, and there is a large time gap in incoming data the file can be
+	// closed (allowing other files to be opened) but will be queued for reopening
+	// when new data is detected. If reading, the file will be closed after
+	// close_older seconds from when the last bytes were read.
+	CloseOlder int `mapstructure:"close_older"`
+
+	// Not implemented
+	Codec string `mapstructure:"codec"`
+
+	// Set the new line delimiter. Default value is "\n"
+	Delimiter string `mapstructure:"delimiter"`
+
+	// How often (in seconds) we expand the filename patterns in the path option
+	// to discover new files to watch. Default value is 15
+	DiscoverInterval int `mapstructure:"discover_interval"`
+
+	// Exclusions (matched against the filename, not full path).
+	// Filename patterns are valid here, too.
+	Exclude []string `mapstructure:"exclude"`
+
+	// When the file input discovers a file that was last modified before the
+	// specified timespan in seconds, the file is ignored.
+	// After it’s discovery, if an ignored file is modified it is no longer ignored
+	// and any new data is read.
+	// Default value is 86400 (i.e. 24 hours)
+	IgnoreOlder int `mapstructure:"ignore_older"`
+
+	// What is the maximum number of file_handles that this input consumes at any one time.
+	// Use close_older to close some files if you need to process more files than this number.
+	MaxOpenFiles string `mapstructure:"max_open_files"`
+
+	// The path(s) to the file(s) to use as an input.
+	// You can use filename patterns here, such as /var/log/*.log.
+	// If you use a pattern like /var/log/**/*.log, a recursive search of /var/log
+	// will be done for all *.log files.
+	// Paths must be absolute and cannot be relative.
+	// You may also configure multiple paths.
+	Path []string `mapstructure:"path" validate:"required"`
+
+	// Path of the sincedb database file
+	// The sincedb database keeps track of the current position of monitored
+	// log files that will be written to disk.
+	SincedbPath string `mapstructure:"sincedb_path"`
+
+	// How often (in seconds) to write a since database with the current position of monitored log files.
+	// Default value is 15
+	SincedbWriteInterval int `mapstructure:"sincedb_write_interval"`
+
+	// Choose where Logfan starts initially reading files: at the beginning or at the end.
+	// The default behavior treats files like live streams and thus starts at the end.
+	// If you have old data you want to import, set this to beginning.
+	// This option only modifies "first contact" situations where a file is new
+	// and not seen before, i.e. files that don’t have a current position recorded in a sincedb file.
+	// If a file has already been seen before, this option has no effect and the
+	// position recorded in the sincedb file will be used.
+	// Default value is "end"
+	// Value can be any of: "beginning", "end"
+	StartPosition string `mapstructure:"start_position"`
+
+	// How often (in seconds) we stat files to see if they have been modified.
+	// Increasing this interval will decrease the number of system calls we make,
+	// but increase the time to detect new log lines.
+	// Default value is 1
+	StatInterval int `mapstructure:"stat_interval"`
+
+	// Add any number of arbitrary tags to your event. There is no default value for this setting.
+	// This can help with processing later. Tags can be dynamic and include parts of the event using the %{field} syntax.
+	Tags []string `mapstructure:"tags"`
+
+	// Add a type field to all events handled by this input.
+	// Types are used mainly for filter activation.
+	Type string `mapstructure:"type"`
 }
 
 func (p *processor) Configure(ctx veino.ProcessorContext, conf map[string]interface{}) error {
-	p.opt.Start_position = "end"
-	p.opt.Sincedb_path = ".sincedb.json"
-	p.opt.Sincedb_write_interval = 15
-	p.opt.Stat_interval = 1
+	p.opt.StartPosition = "end"
+	p.opt.SincedbPath = ".sincedb.json"
+	p.opt.SincedbWriteInterval = 15
+	p.opt.StatInterval = 1
+	p.host = fqdn.Get()
 
 	if usr, err := user.Current(); err == nil {
-		p.opt.Sincedb_path = usr.HomeDir + "/" + p.opt.Sincedb_path
+		p.opt.SincedbPath = usr.HomeDir + "/" + p.opt.SincedbPath
 	}
 
 	return p.ConfigureAndValidate(ctx, conf, p.opt)
 }
+
 func (p *processor) Start(e veino.IPacket) error {
-	watch.POLL_DURATION = time.Second * time.Duration(p.opt.Stat_interval)
+	watch.POLL_DURATION = time.Second * time.Duration(p.opt.StatInterval)
 	p.q = make(chan bool)
 
 	var matches []string
 
-	for _, current_path := range p.opt.Path {
-		if currentMatches, err := filepath.Glob(current_path); err == nil {
+	for _, currentPath := range p.opt.Path {
+		if currentMatches, err := filepath.Glob(currentPath); err == nil {
 			matches = append(matches, currentMatches...)
 			continue
 		}
-		return fmt.Errorf("glob(%q) failed", current_path)
+		return fmt.Errorf("glob(%q) failed", currentPath)
 	}
 
 	if len(p.opt.Exclude) > 0 {
@@ -87,9 +155,9 @@ func (p *processor) Start(e veino.IPacket) error {
 
 	p.loadSinceDBInfos()
 
-	for _, file_path := range matches {
+	for _, filePath := range matches {
 		p.wg.Add(1)
-		go p.tailFile(file_path, p.q)
+		go p.tailFile(filePath, p.q)
 	}
 
 	go p.checkSaveSinceDBInfosLoop()
@@ -123,7 +191,7 @@ func (p *processor) tailFile(path string, q chan bool) error {
 	p.sinceDBInfosMutex.Unlock()
 
 	if since.Offset == 0 {
-		if p.opt.Start_position == "end" {
+		if p.opt.StartPosition == "end" {
 			whence = os.SEEK_END
 		} else {
 			whence = os.SEEK_SET
@@ -151,22 +219,17 @@ func (p *processor) tailFile(path string, q chan bool) error {
 		t.Stop()
 	}()
 
-	host, err := os.Hostname()
-	if err != nil {
-		p.Logger.Printf("can not get hostname : %s", err.Error())
-	}
-
 	for line := range t.Lines {
 
 		e := p.NewPacket(line.Text, map[string]interface{}{
-			"host":       host,
+			"host":       p.host,
 			"path":       path,
 			"@timestamp": line.Time.Format(veino.VeinoTime),
 		})
 
 		since.Offset, _ = t.Tell()
 
-		processors.ProcessCommonFields(e.Fields(), p.opt.Add_field, p.opt.Tags, p.opt.Type)
+		processors.ProcessCommonFields(e.Fields(), p.opt.AddField, p.opt.Tags, p.opt.Type)
 		p.Send(e)
 		p.checkSaveSinceDBInfos()
 	}

--- a/input-file/sincedb.go
+++ b/input-file/sincedb.go
@@ -24,23 +24,23 @@ func (p *processor) loadSinceDBInfos() (err error) {
 
 	p.sinceDBInfos = map[string]*sinceDBInfo{}
 
-	if p.opt.Sincedb_path == "" || p.opt.Sincedb_path == "/dev/null" {
+	if p.opt.SincedbPath == "" || p.opt.SincedbPath == "/dev/null" {
 		p.Logger.Println("No valid sincedb path")
 		return
 	}
 
-	if _, err := os.Stat(p.opt.Sincedb_path); os.IsNotExist(err) {
-		p.Logger.Printf("sincedb not found: %q", p.opt.Sincedb_path)
+	if _, err := os.Stat(p.opt.SincedbPath); os.IsNotExist(err) {
+		p.Logger.Printf("sincedb not found: %q", p.opt.SincedbPath)
 		return err
 	}
 
-	if raw, err = ioutil.ReadFile(p.opt.Sincedb_path); err != nil {
-		p.Logger.Printf("Read sincedb failed: %q\n%s", p.opt.Sincedb_path, err)
+	if raw, err = ioutil.ReadFile(p.opt.SincedbPath); err != nil {
+		p.Logger.Printf("Read sincedb failed: %q\n%s", p.opt.SincedbPath, err)
 		return
 	}
 
 	if err = json.Unmarshal(raw, &p.sinceDBInfos); err != nil {
-		p.Logger.Printf("Unmarshal sincedb failed: %q\n%s", p.opt.Sincedb_path, err)
+		p.Logger.Printf("Unmarshal sincedb failed: %q\n%s", p.opt.SincedbPath, err)
 		return
 	}
 
@@ -54,7 +54,7 @@ func (p *processor) saveSinceDBInfos() (err error) {
 
 	p.sinceDBLastSaveTime = time.Now()
 
-	if p.opt.Sincedb_path == "" || p.opt.Sincedb_path == "/dev/null" {
+	if p.opt.SincedbPath == "" || p.opt.SincedbPath == "/dev/null" {
 		p.Logger.Println("No valid sincedb path")
 		return
 	}
@@ -69,8 +69,8 @@ func (p *processor) saveSinceDBInfos() (err error) {
 
 	p.sinceDBLastInfosRaw = raw
 
-	if err = ioutil.WriteFile(p.opt.Sincedb_path, raw, 0664); err != nil {
-		p.Logger.Printf("Write sincedb failed: %q\n%s", p.opt.Sincedb_path, err)
+	if err = ioutil.WriteFile(p.opt.SincedbPath, raw, 0664); err != nil {
+		p.Logger.Printf("Write sincedb failed: %q\n%s", p.opt.SincedbPath, err)
 		return
 	}
 
@@ -81,7 +81,7 @@ func (p *processor) checkSaveSinceDBInfos() (err error) {
 	var (
 		raw []byte
 	)
-	if time.Since(p.sinceDBLastSaveTime) > time.Duration(p.opt.Sincedb_write_interval)*time.Second {
+	if time.Since(p.sinceDBLastSaveTime) > time.Duration(p.opt.SincedbWriteInterval)*time.Second {
 		if raw, err = json.Marshal(p.sinceDBInfos); err != nil {
 			p.Logger.Printf("Marshal sincedb failed: %s", err)
 			return
@@ -95,7 +95,7 @@ func (p *processor) checkSaveSinceDBInfos() (err error) {
 
 func (p *processor) checkSaveSinceDBInfosLoop() (err error) {
 	for {
-		time.Sleep(time.Duration(p.opt.Sincedb_write_interval) * time.Second)
+		time.Sleep(time.Duration(p.opt.SincedbWriteInterval) * time.Second)
 		if err = p.checkSaveSinceDBInfos(); err != nil {
 			return
 		}


### PR DESCRIPTION
Using fqdn.Get() instead of os.Hostname() and check it only at startup time:
- `fqdn.Get()` returns fqdn if found then fallback to `os.Hostname()` then fallback to `"unknown"` when hostname cannot be found.
- fqdn/hostname is unlikely to change during logfan run, so get it at plugin startup and cache it instead of requesting it on each event.