### PR TITLE
safely parse tags in AddTags func

### DIFF
--- a/field.go
+++ b/field.go
@@ -86,19 +86,27 @@ func AddFields(fields map[string]interface{}, data *mxj.Map) {
 }
 
 func AddTags(tags []string, data *mxj.Map) {
-	currenttags, err := data.ValueForPath("tags")
-	if err != nil {
-		currenttags = []string{}
+	var currentTags []string
+
+	currentTagsInterface, _ := data.ValueForPath("tags")
+
+	switch v := currentTagsInterface.(type) {
+	case string:
+		currentTags = []string{v}
+	case []string:
+		currentTags = currentTagsInterface.([]string)
+	default:
+		currentTags = []string{}
 	}
 
-	tags_eval := []string{}
+	tagsEval := []string{}
 	for _, t := range tags {
 		Dynamic(&t, data)
-		tags_eval = append(tags_eval, t)
+		tagsEval = append(tagsEval, t)
 	}
 
-	newtags := append(currenttags.([]string), tags_eval...)
-	data.SetValueForPath(newtags, "tags")
+	newTags := append(currentTags, tagsEval...)
+	data.SetValueForPath(newTags, "tags")
 }
 
 func RemoveTags(tags []string, data *mxj.Map) {


### PR DESCRIPTION
Logfan recently panicked with following trace:
```
Jul 13 19:57:17 logs-processor01a logfan[7348]: panic: interface conversion: interface is string, not []string
Jul 13 19:57:17 logs-processor01a logfan[7348]: goroutine 53 [running]:
Jul 13 19:57:17 logs-processor01a logfan[7348]: panic(0xd2c6e0, 0xc8202de4c0)
Jul 13 19:57:17 logs-processor01a logfan[7348]: /nix/store/wz2nx10xv5m6hn5j91w15abxnlz7sjsp-go-1.6.2/share/go/src/runtime/panic.go:481 +0x3e6
Jul 13 19:57:17 logs-processor01a logfan[7348]: github.com/vjeantet/logfan/vendor/github.com/veino/processors.AddTags(0x0, 0x0, 0x0, 0xc8202f88a8)
Jul 13 19:57:17 logs-processor01a logfan[7348]: /home/mirdhyn/w/logfan/src/github.com/vjeantet/logfan/vendor/github.com/veino/processors/field.go:100 +0x28d
Jul 13 19:57:17 logs-processor01a logfan[7348]: github.com/vjeantet/logfan/vendor/github.com/veino/processors/filter-mutate.(*processor).Receive(0xc8202b6000, 0x7efe4c42c218, 0xc8202f88a0, 0x0, 0x0)
Jul 13 19:57:17 logs-processor01a logfan[7348]: /home/mirdhyn/w/logfan/src/github.com/vjeantet/logfan/vendor/github.com/veino/processors/filter-mutate/mutate.go:87 +0xa2
Jul 13 19:57:17 logs-processor01a logfan[7348]: github.com/vjeantet/logfan/vendor/github.com/veino/runtime.(*agent).listen.func1(0xc8202a43c0)
Jul 13 19:57:17 logs-processor01a logfan[7348]: /home/mirdhyn/w/logfan/src/github.com/vjeantet/logfan/vendor/github.com/veino/runtime/agent.go:153 +0x7c2
Jul 13 19:57:17 logs-processor01a logfan[7348]: created by github.com/vjeantet/logfan/vendor/github.com/veino/runtime.(*agent).listen
Jul 13 19:57:17 logs-processor01a logfan[7348]: /home/mirdhyn/w/logfan/src/github.com/vjeantet/logfan/vendor/github.com/veino/runtime/agent.go:160 +0x18f
```

My mutate filter was a simple remove_field statement and none of my inputs were explicitly adding tags:

```
input {
  amqp {
    ...
  }

filter {
  mutate {
    remove_field => ["message"]
  }
}

output {
  elasticsearch2 {
    ...
  }
}
```

Based on the stacktrace, I suspect an issue with *mxj.Map ValueForpath what would have returned an empty string.

To be safe, let's convert the string to a []string in this case.